### PR TITLE
Configure Prisma for Neon/Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # Copy this file to `.env` and fill in values.
 
-# PlanetScale / MySQL connection string
-DATABASE_URL='mysql://USER:PASSWORD@HOST/DATABASE?sslaccept=strict'
+# Prisma Accelerate connection string (Neon)
+DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=YOUR_ACCELERATE_API_KEY"
+
+# Direct Neon connection string for migrations and local tools
+DIRECT_URL="postgresql://USER:PASSWORD@HOST/DATABASE?sslmode=require&channel_binding=require"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ npm install
 2. Environment variables
 
 - Copy `.env.example` to `.env` and set values.
-- The app expects `DATABASE_URL` (MySQL/PlanetScale style connection string).
+- Provide a `DATABASE_URL` using your Prisma Accelerate connection string (e.g. the Neon Accelerate URL).
+- Provide a `DIRECT_URL` using the standard Neon connection string so Prisma can run migrations (`db push`, `migrate`, etc.).
 
 3. Prisma
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,9 +6,9 @@ generator client {
 }
 
 datasource db {
-  provider     = "mysql"
-  url          = env("DATABASE_URL")
-  relationMode = "prisma"
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Person {


### PR DESCRIPTION
## Summary
- switch Prisma datasource to PostgreSQL and wire up Accelerate direct URL support
- document Neon Accelerate and direct connection requirements in the env example and README

## Testing
- DATABASE_URL='postgresql://user:password@localhost:5432/db' DIRECT_URL='postgresql://user:password@localhost:5432/db' npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68d2e2dc3ad4832781b769e1c885da34