### PR TITLE
Fix API connection route exports

### DIFF
--- a/src/app/api/connection/route.js
+++ b/src/app/api/connection/route.js
@@ -1,9 +1,9 @@
-const { PrismaClient } = require("@prisma/client");
-const { NextResponse } = require("next/server");
+import { PrismaClient } from "@prisma/client";
+import { NextResponse } from "next/server";
 
 const prisma = new PrismaClient();
 
-async function GET(request, _) {
+export async function GET(_request) {
   try {
     const users = await prisma.connection.findMany();
     const userArray = users.map((user) => {
@@ -19,7 +19,3 @@ async function GET(request, _) {
     await prisma.$disconnect();
   }
 }
-
-module.exports = {
-  GET,
-};


### PR DESCRIPTION
## Summary
- update the `/api/connection` route handler to use ES module imports and Next.js route handler exports

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d40b5e2bac8327939513e11db9e661