### PR TITLE
Handle missing Prisma env vars and avoid static prefetch

### DIFF
--- a/src/app/api/connection/route.js
+++ b/src/app/api/connection/route.js
@@ -1,9 +1,16 @@
-import { PrismaClient } from "@prisma/client";
 import { NextResponse } from "next/server";
+import { getPrismaClient } from "../../../lib/prisma";
 
-const prisma = new PrismaClient();
+export const dynamic = "force-dynamic";
 
 export async function GET(_request) {
+  const prisma = getPrismaClient();
+
+  if (!prisma) {
+    console.warn("DATABASE_URL is not configured. Returning empty connection list.");
+    return NextResponse.json([]);
+  }
+
   try {
     const users = await prisma.connection.findMany();
     const userArray = users.map((user) => {
@@ -15,7 +22,5 @@ export async function GET(_request) {
   } catch (error) {
     console.error("Error querying database:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  } finally {
-    await prisma.$disconnect();
   }
 }

--- a/src/app/api/namedconnections/route.js
+++ b/src/app/api/namedconnections/route.js
@@ -1,9 +1,16 @@
-const { PrismaClient } = require("@prisma/client");
-const { NextResponse } = require("next/server");
+import { NextResponse } from "next/server";
+import { getPrismaClient } from "../../../lib/prisma";
 
-const prisma = new PrismaClient();
+export const dynamic = "force-dynamic";
 
-async function GET(req, res) {
+export async function GET() {
+  const prisma = getPrismaClient();
+
+  if (!prisma) {
+    console.warn("DATABASE_URL is not configured. Returning empty named connections list.");
+    return NextResponse.json([]);
+  }
+
   try {
     const connectionsWithNames = await prisma.connection.findMany({
       include: {
@@ -23,9 +30,6 @@ async function GET(req, res) {
     return NextResponse.json(connectionsWithNamesAndPersons);
   } catch (error) {
     console.error("Error fetching connections with names:", error);
-    res.status(500).json({ error: "Internal Server Error" });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
-module.exports = {
-  GET,
-};

--- a/src/app/api/node/[id]/route.js
+++ b/src/app/api/node/[id]/route.js
@@ -1,10 +1,21 @@
-const { PrismaClient } = require("@prisma/client");
-const { NextRequest, NextResponse } = require("next/server");
+import { NextResponse } from "next/server";
+import { getPrismaClient } from "../../../../lib/prisma";
 
-const prisma = new PrismaClient();
+export const dynamic = "force-dynamic";
 
-async function GET(request, { params }) {
-  const userId = parseInt(params.id); // Assuming id is a number, parse it if necessary
+export async function GET(_request, { params }) {
+  const prisma = getPrismaClient();
+
+  if (!prisma) {
+    console.warn("DATABASE_URL is not configured. Returning not found response for node lookup.");
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const userId = Number.parseInt(params.id, 10);
+
+  if (Number.isNaN(userId)) {
+    return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
+  }
 
   try {
     const user = await prisma.person.findUnique({
@@ -13,29 +24,23 @@ async function GET(request, { params }) {
       },
     });
 
-    if (user) {
-      const { id, firstName, lastName, city, state, color, age } = user;
-      const json = {
-        id,
-        firstName,
-        lastName,
-        city,
-        state,
-        color,
-        age,
-      };
-      return NextResponse.json(json);
-    } else {
+    if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
+
+    const { id, firstName, lastName, city, state, color, age } = user;
+    const json = {
+      id,
+      firstName,
+      lastName,
+      city,
+      state,
+      color,
+      age,
+    };
+    return NextResponse.json(json);
   } catch (error) {
     console.error("Error querying database:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  } finally {
-    await prisma.$disconnect();
   }
 }
-
-module.exports = {
-  GET,
-};

--- a/src/app/api/node/route.js
+++ b/src/app/api/node/route.js
@@ -1,9 +1,16 @@
-const { PrismaClient } = require("@prisma/client");
-const { NextResponse } = require("next/server");
+import { NextResponse } from "next/server";
+import { getPrismaClient } from "../../../lib/prisma";
 
-const prisma = new PrismaClient();
+export const dynamic = "force-dynamic";
 
-async function GET(request, _) {
+export async function GET() {
+  const prisma = getPrismaClient();
+
+  if (!prisma) {
+    console.warn("DATABASE_URL is not configured. Returning empty person list.");
+    return NextResponse.json([]);
+  }
+
   try {
     const users = await prisma.person.findMany();
     const userArray = users.map((user) => {
@@ -15,11 +22,5 @@ async function GET(request, _) {
   } catch (error) {
     console.error("Error querying database:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  } finally {
-    await prisma.$disconnect();
   }
 }
-
-module.exports = {
-  GET,
-};

--- a/src/app/api/usersconnections/route.js
+++ b/src/app/api/usersconnections/route.js
@@ -1,9 +1,16 @@
-const { PrismaClient } = require("@prisma/client");
-const { NextResponse } = require("next/server");
+import { NextResponse } from "next/server";
+import { getPrismaClient } from "../../../lib/prisma";
 
-const prisma = new PrismaClient();
+export const dynamic = "force-dynamic";
 
-async function GET(request, _) {
+export async function GET() {
+  const prisma = getPrismaClient();
+
+  if (!prisma) {
+    console.warn("DATABASE_URL is not configured. Returning empty users connections list.");
+    return NextResponse.json({ users: [], connections: [] });
+  }
+
   try {
     const connections = await prisma.connection.findMany({
       where: {
@@ -14,9 +21,9 @@ async function GET(request, _) {
     const userIds = connections.map((connection) => {
       if (connection.personOne !== 2) {
         return connection.personOne;
-      } else {
-        return connection.personTwo;
       }
+
+      return connection.personTwo;
     });
 
     if (!userIds.includes(2)) {
@@ -45,11 +52,5 @@ async function GET(request, _) {
   } catch (error) {
     console.error("Error querying database:", error);
     return NextResponse.json({ error: error.message || "Internal server error" }, { status: 500 });
-  } finally {
-    await prisma.$disconnect();
   }
 }
-
-module.exports = {
-  GET,
-};

--- a/src/app/connect/page.js
+++ b/src/app/connect/page.js
@@ -1,21 +1,12 @@
 import React from "react";
-import { create, createConnection } from "../../lib/prisma";
+import { create } from "../../lib/prisma";
 import Drawer from "../../components/Drawer";
 
 export default async function page() {
-  async function createNodeRelationship(userData) {
-    "use server";
-    try {
-      createConnection(userData);
-    } catch (error) {
-      console.error("Error creating user:", error);
-    }
-  }
-
   async function createNode(userData) {
     "use server";
     try {
-      create(userData);
+      await create(userData);
     } catch (error) {
       console.error("Error creating user:", error);
     }
@@ -24,7 +15,7 @@ export default async function page() {
   return (
     <>
       <div>
-        <Drawer connect={createNodeRelationship} create={createNode}></Drawer>
+        <Drawer create={createNode}></Drawer>
       </div>
     </>
   );

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,7 +1,4 @@
 import "./globals.css";
-import { Inter } from "next/font/google";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
   title: "The Chart",
@@ -11,7 +8,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -34,7 +34,7 @@ const darkTheme = createTheme({
   },
 });
 
-export default function PermanentDrawerLeft({ create, connect }) {
+export default function PermanentDrawerLeft({ create }) {
   const [state, setState] = useState({
     node: false,
     connectButton: false,

--- a/src/lib/prisma.js
+++ b/src/lib/prisma.js
@@ -1,18 +1,41 @@
 import { PrismaClient } from "@prisma/client";
 
-const prisma = (global.prisma = new PrismaClient());
+let prismaClient = globalThis.__prismaClient ?? null;
 
-async function create(event) {
+export function getPrismaClient() {
+  if (!process.env.DATABASE_URL) {
+    return null;
+  }
+
+  if (!prismaClient) {
+    prismaClient = new PrismaClient();
+
+    if (process.env.NODE_ENV !== "production") {
+      globalThis.__prismaClient = prismaClient;
+    }
+  }
+
+  return prismaClient;
+}
+
+export async function create(formData) {
   "use server";
-  var nameValue = event.get("name");
-  var lastNameValue = event.get("last");
-  var emailValue = event.get("email");
-  var colorValue = event.get("color");
-  var ageValue = event.get("age");
-  var cityValue = event.get("city");
-  var stateValue = event.get("state");
 
-  // Create a new user
+  const prisma = getPrismaClient();
+
+  if (!prisma) {
+    console.error("DATABASE_URL is not configured. Skipping create operation.");
+    return;
+  }
+
+  const nameValue = formData.get("name");
+  const lastNameValue = formData.get("last");
+  const emailValue = formData.get("email");
+  const colorValue = formData.get("color");
+  const ageValue = formData.get("age");
+  const cityValue = formData.get("city");
+  const stateValue = formData.get("state");
+
   const newUser = await prisma.person.create({
     data: {
       firstName: nameValue,
@@ -25,7 +48,6 @@ async function create(event) {
     },
   });
 
-  // Connect the new user to an existing user with the given ID
   await prisma.connection.create({
     data: {
       personOneDetails: {
@@ -37,45 +59,3 @@ async function create(event) {
     },
   });
 }
-
-// async function createConnection(event) {
-//     const inputValueOne = event.get("personOne");
-//     const inputValueTwo = event.get("personTwo");
-
-//     // Query the database to find personOne and personTwo based on names
-//     const personOne = await prisma.person.findFirst({
-//         where: {
-//             firstName: inputValueOne,
-//         },
-//     });
-
-//     const personTwo = await prisma.person.findFirst({
-//         where: {
-//             firstName: inputValueTwo,
-//         },
-//     });
-
-//     // Check if both persons were found
-//     if (!personOne || !personTwo) {
-//         throw new Error("Invalid person names provided");
-//     }
-
-//     // Create the connection using the retrieved person IDs and correct format
-//     await prisma.connection.create({
-//         data: {
-//             personOneDetails: {
-//                 connect: { id: personOne.id }
-//             },
-//             personTwoDetails: {
-//                 connect: { id: personTwo.id }
-//             }
-//         },
-//     });
-// }
-
-if (process.env.NODE_ENV === "development") global.prisma = prisma;
-
-module.exports = {
-  create,
-  prisma,
-};


### PR DESCRIPTION
## Summary
- add a shared Prisma helper that skips initialization when DATABASE_URL is missing and reuse the client in development
- update API routes to use the helper, force dynamic rendering, and return safe fallbacks when the database is unavailable
- remove the Google font dependency during build and clean up server actions/props around the connect drawer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40dc1c86883279efe5a8104dd5810